### PR TITLE
Rework the --distributions flag of the remote command

### DIFF
--- a/CHANGES/14.bugfix
+++ b/CHANGES/14.bugfix
@@ -1,0 +1,1 @@
+Reworked the ``--distribution`` flag for the remote command. It is no longer required when updating a remote, and can now be specified multiple times (instead of a single ``--distributions`` flag).

--- a/pulpcore/cli/deb/context.py
+++ b/pulpcore/cli/deb/context.py
@@ -76,6 +76,13 @@ class PulpAptRemoteContext(PulpEntityContext):
     UPDATE_ID = "remotes_deb_apt_partial_update"
     DELETE_ID = "remotes_deb_apt_delete"
 
+    def preprocess_body(self, body: EntityDefinition) -> EntityDefinition:
+        body = super().preprocess_body(body)
+        distributions = body.pop("distributions", None)
+        if isinstance(distributions, tuple) and distributions:
+            body["distributions"] = " ".join(distributions)
+        return body
+
 
 class PulpAptRepositoryVersionContext(PulpRepositoryVersionContext):
     HREF = "deb_apt_repository_version_href"

--- a/pulpcore/cli/deb/remote.py
+++ b/pulpcore/cli/deb/remote.py
@@ -39,18 +39,43 @@ def remote(ctx: click.Context, pulp_ctx: PulpContext, remote_type: str) -> None:
 
 
 lookup_options = [href_option, name_option]
-apt_remote_options = [
+apt_remote_common_options = [
     click.option(
         "--policy", type=click.Choice(["immediate", "on_demand", "streamed"], case_sensitive=False)
     ),
-    click.option("--distributions", required=True),
 ]
+
+distribution_help = _("Distribution to sync; can be specified multiple times.")
+apt_remote_create_options = (
+    common_remote_create_options
+    + apt_remote_common_options
+    + [
+        click.option(
+            "--distribution",
+            "distributions",
+            multiple=True,
+            required=True,
+            help=distribution_help,
+        ),
+    ]
+)
+apt_remote_update_options = (
+    lookup_options
+    + common_remote_update_options
+    + apt_remote_common_options
+    + [
+        click.option(
+            "--distribution",
+            "distributions",
+            multiple=True,
+            help=distribution_help,
+        ),
+    ]
+)
 
 remote.add_command(list_command(decorators=[label_select_option]))
 remote.add_command(show_command(decorators=lookup_options))
-remote.add_command(create_command(decorators=common_remote_create_options + apt_remote_options))
-remote.add_command(
-    update_command(decorators=lookup_options + common_remote_update_options + apt_remote_options)
-)
+remote.add_command(create_command(decorators=apt_remote_create_options))
+remote.add_command(update_command(decorators=apt_remote_update_options))
 remote.add_command(destroy_command(decorators=lookup_options))
 remote.add_command(label_command())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def pulp_cli_vars(pulp_cli_vars):
     result.update(
         {
             "DEB_REMOTE_URL": urljoin(PULP_FIXTURES_URL, "/debian"),
-            "DEB_DISTRIBUTIONS": "ragnarok",
+            "DEB_DISTRIBUTION": "ragnarok",
         }
     )
     return result

--- a/tests/scripts/pulp_deb/test_deb_sync_publish.sh
+++ b/tests/scripts/pulp_deb/test_deb_sync_publish.sh
@@ -17,7 +17,7 @@ else
   curl_opt=""
 fi
 
-expect_succ pulp deb remote create --name "cli_test_deb_remote" --url "$DEB_REMOTE_URL" --distributions "$DEB_DISTRIBUTIONS"
+expect_succ pulp deb remote create --name "cli_test_deb_remote" --url "$DEB_REMOTE_URL" --distribution "$DEB_DISTRIBUTION"
 expect_succ pulp deb repository create --name "cli_test_deb_repository"
 
 expect_succ pulp deb repository sync --name "cli_test_deb_repository" --remote "cli_test_deb_remote"


### PR DESCRIPTION
closes #14

* The flag is renamed to --distribution and may be specified multiple
  times.
* The flag is no longer required when updating a remote.