### PR TITLE
Use flags for publish type

### DIFF
--- a/CHANGES/36.feature
+++ b/CHANGES/36.feature
@@ -1,0 +1,2 @@
+Use flags for ``--simple`` and ``--structured`` on publication create instead of having users
+specify a value of ``True``.

--- a/pulpcore/cli/deb/publication.py
+++ b/pulpcore/cli/deb/publication.py
@@ -57,13 +57,13 @@ create_options = [
     ),
     click.option(
         "--simple",
-        type=bool,
+        is_flag=True,
         default=None,
         help=_("Apt only: Activate simple publishing mode"),
     ),
     click.option(
         "--structured",
-        type=bool,
+        is_flag=True,
         default=None,
         help=_("Apt only: Activate structured publishing mode"),
     ),

--- a/tests/scripts/pulp_deb/test_deb_sync_publish.sh
+++ b/tests/scripts/pulp_deb/test_deb_sync_publish.sh
@@ -43,7 +43,7 @@ fi
 
 expect_succ pulp deb publication create \
   --repository "${ENTITIES_NAME}_repo" \
-  --simple "True"
+  --simple
 
 PUBLICATION_HREF=$(echo "$OUTPUT" | jq -r .pulp_href)
 


### PR DESCRIPTION
I think this makes the command more consistent with pulp-cli which uses flags for boolean values.