### PR TITLE
Add deb package management feature. 

### DIFF
--- a/CHANGES/20.feature
+++ b/CHANGES/20.feature
@@ -1,0 +1,1 @@
+Adding content upload and management commands to match deb equivelent of rpm commands.

--- a/pulpcore/cli/deb/__init__.py
+++ b/pulpcore/cli/deb/__init__.py
@@ -6,6 +6,7 @@ from pulpcore.cli.deb.distribution import distribution
 from pulpcore.cli.deb.publication import publication
 from pulpcore.cli.deb.remote import remote
 from pulpcore.cli.deb.repository import repository
+from pulpcore.cli.deb.content import content
 
 
 @main.group()
@@ -18,3 +19,4 @@ deb.add_command(distribution)
 deb.add_command(publication)
 deb.add_command(remote)
 deb.add_command(repository)
+deb.add_command(content)

--- a/pulpcore/cli/deb/__init__.py
+++ b/pulpcore/cli/deb/__init__.py
@@ -2,11 +2,11 @@ from pulpcore.cli.common import main
 from pulpcore.cli.common.context import PluginRequirement
 from pulpcore.cli.common.generic import PulpCLIContext, pass_pulp_context
 
+from pulpcore.cli.deb.content import content
 from pulpcore.cli.deb.distribution import distribution
 from pulpcore.cli.deb.publication import publication
 from pulpcore.cli.deb.remote import remote
 from pulpcore.cli.deb.repository import repository
-from pulpcore.cli.deb.content import content
 
 
 @main.group()

--- a/pulpcore/cli/deb/content.py
+++ b/pulpcore/cli/deb/content.py
@@ -1,0 +1,207 @@
+from typing import IO, Any, Dict, Optional, Union
+
+import click
+from pulp_glue.common.context import PulpEntityContext
+from pulp_glue.common.i18n import get_translation
+from pulp_glue.core.context import PulpArtifactContext
+from pulpcore.cli.deb.context import (
+    PulpDebPackageContext,
+    PulpAptRepositoryContext,
+)
+
+from pulpcore.cli.common.generic import (
+    PulpCLIContext,
+    chunk_size_option,
+    create_command,
+    exclude_field_option,
+    field_option,
+    href_option,
+    list_command,
+    pass_entity_context,
+    pass_pulp_context,
+    pulp_group,
+    pulp_option,
+    resource_option,
+    show_command,
+    type_option,
+)
+
+translation = get_translation(__name__)
+_ = translation.gettext
+
+
+def _relative_path_callback(ctx: click.Context, param: click.Parameter, value: str) -> str:
+    if value is not None:
+        entity_ctx = ctx.find_object(PulpEntityContext)
+        assert entity_ctx is not None
+        entity_ctx.entity = {"relative_path": value}
+    return value
+
+
+def _sha256_callback(ctx: click.Context, param: click.Parameter, value: str) -> str:
+    if value is not None:
+        entity_ctx = ctx.find_object(PulpEntityContext)
+        assert entity_ctx is not None
+        entity_ctx.entity = {"sha256": value}
+    return value
+
+
+def _sha256_artifact_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[str]
+) -> Optional[Union[str, PulpEntityContext]]:
+    # Pass None and "" verbatim
+    if value:
+        pulp_ctx = ctx.find_object(PulpCLIContext)
+        assert pulp_ctx is not None
+        return PulpArtifactContext(pulp_ctx, entity={"sha256": value})
+    return value
+
+
+repository_option = resource_option(
+    "--repository",
+    default_plugin="deb",
+    default_type="deb",
+    context_table={
+        "deb:deb": PulpAptRepositoryContext,
+    },
+    href_pattern=PulpAptRepositoryContext.HREF_PATTERN,
+    help=_(
+        "Repository to add the content to in the form '[[<plugin>:]<resource_type>:]<name>' or by "
+        "href."
+    ),
+    allowed_with_contexts=(PulpDebPackageContext,),
+)
+
+
+@pulp_group()
+@type_option(
+    choices={
+        "package": PulpDebPackageContext,
+    },
+    default="package",
+    case_sensitive=False,
+)
+def content() -> None:
+    pass
+
+
+list_options = [
+    field_option,
+    exclude_field_option,
+    pulp_option("--repository-version"),
+    pulp_option("--arch", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option(
+        "--arch-in", "arch__in", multiple=True, allowed_with_contexts=(PulpDebPackageContext,)
+    ),
+    pulp_option("--arch-ne", "arch__ne", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option("--epoch", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option(
+        "--epoch-in", "epoch__in", multiple=True, allowed_with_contexts=(PulpDebPackageContext,)
+    ),
+    pulp_option("--epoch-ne", "epoch__ne", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option("--package-href", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option("--pkgId", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option(
+        "--pkgId-in",
+        "pkgId__in",
+        multiple=True,
+        allowed_with_contexts=(PulpDebPackageContext,),
+    ),
+    pulp_option("--release", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option(
+        "--release-in", "release__in", multiple=True, allowed_with_contexts=(PulpDebPackageContext,)
+    ),
+    pulp_option("--release-ne", "release__ne", allowed_with_contexts=(PulpDebPackageContext,)),
+    pulp_option(
+        "--version-in", "version__in", multiple=True, allowed_with_contexts=(PulpDebPackageContext,)
+    ),
+    pulp_option("--version-ne", "version__ne", allowed_with_contexts=(PulpDebPackageContext,)),
+]
+lookup_options = [
+    href_option,
+    pulp_option(
+        "--relative-path",
+        callback=_relative_path_callback,
+        expose_value=False,
+        allowed_with_contexts=(PulpDebPackageContext,),
+    ),
+    pulp_option(
+        "--sha256",
+        callback=_sha256_callback,
+        expose_value=False,
+        allowed_with_contexts=(
+            PulpDebPackageContext,
+        ),
+    ),
+]
+
+content.add_command(list_command(decorators=list_options))
+content.add_command(show_command(decorators=lookup_options))
+# create assumes "there exists an Artifact..."
+# create is defined for package, modulemd and modulemd_defaults.  The implications for modulemd
+# and modulemd_defaults are generally not what the user expects. Therefore, leaving those two
+# endpoints hidden until we have a better handle on what we should really be doing.
+# See https://github.com/pulp/pulp_deb/issues/2229 and https://github.com/pulp/pulp_deb/issues/2534
+create_options = [
+    pulp_option(
+        "--relative-path",
+        allowed_with_contexts=(PulpDebPackageContext,),
+    ),
+    pulp_option(
+        "--sha256",
+        "artifact",
+        required=True,
+        help=_("Digest of the artifact to use"),
+        callback=_sha256_artifact_callback,
+        allowed_with_contexts=(PulpDebPackageContext,),
+    ),
+    repository_option,
+]
+content.add_command(
+    create_command(
+        decorators=create_options,
+        allowed_with_contexts=(PulpDebPackageContext,),
+    )
+)
+
+
+# upload takes a file-argument and creates the entity from it.
+# upload currently only works for advisory/package,
+# see https://github.com/pulp/pulp_deb/issues/2534
+@content.command(
+    allowed_with_contexts=(
+        PulpDebPackageContext,
+    )
+)
+@chunk_size_option
+@pulp_option(
+    "--relative-path",
+    help=_("Relative path within a distribution of the entity"),
+    allowed_with_contexts=(PulpDebPackageContext,),
+)
+@pulp_option(
+    "--file",
+    type=click.File("rb"),
+    required=True,
+    help=_("An DEB binary"),
+    allowed_with_contexts=(PulpDebPackageContext,),
+)
+@repository_option
+@pass_entity_context
+@pass_pulp_context
+def upload(
+    pulp_ctx: PulpCLIContext,
+    entity_ctx: Union[
+        PulpDebPackageContext,
+    ],
+    file: IO[bytes],
+    chunk_size: int,
+    **kwargs: Any,
+) -> None:
+    """Create a content unit by uploading a file"""
+    body: Dict[str, Any]
+    if isinstance(entity_ctx, PulpDebPackageContext):
+        result = entity_ctx.upload(file=file, chunk_size=chunk_size, **kwargs)
+    else:
+        raise NotImplementedError()
+    pulp_ctx.output_result(result)

--- a/pulpcore/cli/deb/content.py
+++ b/pulpcore/cli/deb/content.py
@@ -1,14 +1,9 @@
-from typing import IO, Any, Dict, Optional, Union
+from typing import IO, Any, Optional, Union
 
 import click
 from pulp_glue.common.context import PulpEntityContext
 from pulp_glue.common.i18n import get_translation
 from pulp_glue.core.context import PulpArtifactContext
-from pulpcore.cli.deb.context import (
-    PulpDebPackageContext,
-    PulpAptRepositoryContext,
-)
-
 from pulpcore.cli.common.generic import (
     PulpCLIContext,
     chunk_size_option,
@@ -25,6 +20,8 @@ from pulpcore.cli.common.generic import (
     show_command,
     type_option,
 )
+
+from pulpcore.cli.deb.context import PulpAptRepositoryContext, PulpDebPackageContext
 
 translation = get_translation(__name__)
 _ = translation.gettext
@@ -129,9 +126,7 @@ lookup_options = [
         "--sha256",
         callback=_sha256_callback,
         expose_value=False,
-        allowed_with_contexts=(
-            PulpDebPackageContext,
-        ),
+        allowed_with_contexts=(PulpDebPackageContext,),
     ),
 ]
 
@@ -168,11 +163,7 @@ content.add_command(
 # upload takes a file-argument and creates the entity from it.
 # upload currently only works for advisory/package,
 # see https://github.com/pulp/pulp_deb/issues/2534
-@content.command(
-    allowed_with_contexts=(
-        PulpDebPackageContext,
-    )
-)
+@content.command(allowed_with_contexts=(PulpDebPackageContext,))
 @chunk_size_option
 @pulp_option(
     "--relative-path",
@@ -199,7 +190,6 @@ def upload(
     **kwargs: Any,
 ) -> None:
     """Create a content unit by uploading a file"""
-    body: Dict[str, Any]
     if isinstance(entity_ctx, PulpDebPackageContext):
         result = entity_ctx.upload(file=file, chunk_size=chunk_size, **kwargs)
     else:

--- a/pulpcore/cli/deb/context.py
+++ b/pulpcore/cli/deb/context.py
@@ -3,9 +3,9 @@ from typing import ClassVar, Set
 import click
 from pulpcore.cli.common.context import (
     EntityDefinition,
+    PulpContentContext,
     PulpEntityContext,
     PulpException,
-    PulpContentContext,
     PulpRepositoryContext,
     PulpRepositoryVersionContext,
     registered_repository_contexts,

--- a/pulpcore/cli/deb/context.py
+++ b/pulpcore/cli/deb/context.py
@@ -5,6 +5,7 @@ from pulpcore.cli.common.context import (
     EntityDefinition,
     PulpEntityContext,
     PulpException,
+    PulpContentContext,
     PulpRepositoryContext,
     PulpRepositoryVersionContext,
     registered_repository_contexts,
@@ -13,6 +14,13 @@ from pulpcore.cli.common.i18n import get_translation
 
 translation = get_translation(__name__)
 _ = translation.gettext
+
+
+class PulpDebPackageContext(PulpContentContext):
+    ENTITY = "deb package"
+    ENTITIES = "deb packages"
+    HREF = "deb_package_href"
+    ID_PREFIX = "content_deb_packages"
 
 
 class PulpAptDistributionContext(PulpEntityContext):
@@ -93,6 +101,10 @@ class PulpAptRepositoryVersionContext(PulpRepositoryVersionContext):
     HREF = "deb_apt_repository_version_href"
     REPOSITORY_HREF = "deb_apt_repository_href"
     ID_PREFIX = "repositories_deb_apt_versions"
+    LIST_ID = "repositories_deb_apt_versions_list"
+    READ_ID = "repositories_deb_apt_versions_read"
+    DELETE_ID = "repositories_deb_apt_versions_delete"
+    MODIFY_ID = "repositories_deb_apt_modify"
 
 
 class PulpAptRepositoryContext(PulpRepositoryContext):
@@ -100,6 +112,13 @@ class PulpAptRepositoryContext(PulpRepositoryContext):
     ENTITIES = _("apt repositories")
     HREF = "deb_apt_repository_href"
     ID_PREFIX = "repositories_deb_apt"
+    LIST_ID = "repositories_deb_apt_list"
+    READ_ID = "repositories_deb_apt_read"
+    CREATE_ID = "repositories_deb_apt_create"
+    UPDATE_ID = "repositories_deb_apt_partial_update"
+    DELETE_ID = "repositories_deb_apt_delete"
+    MODIFY_ID = "repositories_deb_apt_modify"
+    SYNC_ID = "repositories_deb_apt_sync"
     VERSION_CONTEXT = PulpAptRepositoryVersionContext
 
 

--- a/pulpcore/cli/deb/repository.py
+++ b/pulpcore/cli/deb/repository.py
@@ -2,10 +2,10 @@ from typing import Any, Dict, Optional
 
 import click
 import schema as s
-
 from pulpcore.cli.common.context import (
     EntityFieldDefinition,
     PluginRequirement,
+    PulpContext,
     PulpEntityContext,
     PulpRepositoryContext,
 )

--- a/pulpcore/cli/deb/repository.py
+++ b/pulpcore/cli/deb/repository.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Optional
 
 import click
+import schema as s
+
 from pulpcore.cli.common.context import (
     EntityFieldDefinition,
     PluginRequirement,
@@ -10,6 +12,7 @@ from pulpcore.cli.common.context import (
 from pulpcore.cli.common.generic import (
     PulpCLIContext,
     create_command,
+    create_content_json_callback,
     destroy_command,
     href_option,
     label_command,
@@ -19,6 +22,7 @@ from pulpcore.cli.common.generic import (
     pass_pulp_context,
     pass_repository_context,
     pulp_option,
+    repository_content_command,
     repository_href_option,
     repository_option,
     resource_option,
@@ -30,11 +34,58 @@ from pulpcore.cli.common.generic import (
 from pulpcore.cli.common.i18n import get_translation
 from pulpcore.cli.core.generic import task_command
 
-from pulpcore.cli.deb.context import PulpAptRemoteContext, PulpAptRepositoryContext
+from pulpcore.cli.deb.context import (
+    PulpAptRemoteContext,
+    PulpAptRepositoryContext,
+    PulpDebPackageContext,
+)
 
 translation = get_translation(__name__)
 _ = translation.gettext
 
+
+def _content_callback(ctx: click.Context, param: click.Parameter, value: Any) -> Any:
+    if value:
+        pulp_ctx = ctx.find_object(PulpContext)
+        assert pulp_ctx is not None
+        ctx.obj = PulpDebPackageContext(pulp_ctx, pulp_href=value)
+    return value
+
+
+CONTENT_LIST_SCHEMA = s.Schema([{"pulp_href": str}])
+
+package_options = [
+    click.option(
+        "--package-href",
+        callback=_content_callback,
+        expose_value=False,
+        help=_("Href of the deb package to use"),
+    )
+]
+
+content_json_callback = create_content_json_callback(
+    PulpDebPackageContext, schema=CONTENT_LIST_SCHEMA
+)
+modify_options = [
+    click.option(
+        "--add-content",
+        callback=content_json_callback,
+        help=_(
+            """JSON string with a list of objects to add to the repository.
+    Each object must contain the following keys: "pulp_href".
+    The argument prefixed with the '@' can be the path to a JSON file with a list of objects."""
+        ),
+    ),
+    click.option(
+        "--remove-content",
+        callback=content_json_callback,
+        help=_(
+            """JSON string with a list of objects to remove from the repository.
+    Each object must contain the following keys: "pulp_href".
+    The argument prefixed with the '@' can be the path to a JSON file with a list of objects."""
+        ),
+    ),
+]
 
 remote_option = resource_option(
     "--remote",
@@ -84,6 +135,14 @@ repository.add_command(destroy_command(decorators=lookup_options))
 repository.add_command(task_command(decorators=nested_lookup_options))
 repository.add_command(version_command(decorators=nested_lookup_options))
 repository.add_command(label_command(decorators=nested_lookup_options))
+repository.add_command(
+    repository_content_command(
+        contexts={"package": PulpDebPackageContext},
+        add_decorators=package_options,
+        remove_decorators=package_options,
+        modify_decorators=modify_options,
+    )
+)
 
 
 @repository.command()


### PR DESCRIPTION
This will allow the pulp-deb-cli to mange packages in a deb repository just like the rpm cli. 

fixes [#20](https://github.com/pulp/pulp-cli-deb/issues/20): Feature added content management feature.
[#23](https://github.com/pulp/pulp-cli-deb/issues/23): Duplicate of 20

Known Issues:
* Help for non-content commands don't appear with the 'pulp deb'.  This worked in v0.0.3, but I'm not able to find the cause.
