### PR TITLE
Fix changelog template

### DIFF
--- a/CHANGES/.TEMPLATE.md
+++ b/CHANGES/.TEMPLATE.md
@@ -1,18 +1,20 @@
 
 {# TOWNCRIER TEMPLATE #}
 {% for section, _ in sections.items() %}
-{% if section %}## {{section}}
+{% if section %}### {{section}}
 
 {% endif %}
 
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
-### {{ definitions[category]['name'] }}
+#### {{ definitions[category]['name'] }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
 - {{ text }}
+{% if values %}
   {{ values|join(',\n  ') }}
+{% endif %}
 {% endfor %}
 
 {% else %}
@@ -33,3 +35,5 @@ No significant changes.
 {% endif %}
 {% endfor %}
 ---
+
+


### PR DESCRIPTION
[noissue]

This brings the template in line with the ones in pulp-cli and pulp-cli-gem, and will hopefully prevent broken formatting as found here: https://github.com/pulp/pulp-cli-deb/blob/0.0/CHANGES.md going forwards.