### PR TITLE
Bump pulp-cli dependency to 0.29.*

### DIFF
--- a/CHANGES/138.feature
+++ b/CHANGES/138.feature
@@ -1,0 +1,1 @@
+Bump dependency on pulp-cli up to version 0.29.*.

--- a/CHANGES/pulp-glue-deb/138.feature
+++ b/CHANGES/pulp-glue-deb/138.feature
@@ -1,0 +1,1 @@
+Bump dependency on pulp-glue up to version 0.29.*.

--- a/pulp-glue-deb/pyproject.toml
+++ b/pulp-glue-deb/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "pulp-glue>=0.23.2,<0.28",
+  "pulp-glue>=0.23.2,<0.30",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
   "Typing :: Typed",
 ]
 dependencies = [
-  "pulp-cli>=0.23.2,<0.28",
+  "pulp-cli>=0.23.2,<0.30",
   "pulp-glue-deb==0.3.0.dev",
 ]
 


### PR DESCRIPTION
Allow pulp-cli up to version 0.29.* to be installed

fixes #138