### PR TITLE
Fix pulp-cli-deb missing pulpexport capability

### DIFF
--- a/CHANGES/40.bugfix
+++ b/CHANGES/40.bugfix
@@ -1,0 +1,1 @@
+Fix error "The type 'deb:apt' does not support the 'pulpexport' capability."

--- a/pulp-glue-deb/pulp_glue/deb/context.py
+++ b/pulp-glue-deb/pulp_glue/deb/context.py
@@ -218,3 +218,4 @@ class PulpAptRepositoryContext(PulpRepositoryContext):
     PLUGIN = "deb"
     RESOURCE_TYPE = "apt"
     VERSION_CONTEXT = PulpAptRepositoryVersionContext
+    CAPABILITIES = {"pulpexport": [PluginRequirement("deb", "2.20.0")]}


### PR DESCRIPTION
fixes: #40

replacing https://github.com/pulp/pulp-cli-deb/pull/41/