### PR TITLE
Bump version: 0.3.0.dev → 0.4.0.dev

### DIFF
--- a/pulp-glue-deb/pulp_glue/deb/__init__.py
+++ b/pulp-glue-deb/pulp_glue/deb/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0.dev"
+__version__ = "0.4.0.dev"

--- a/pulp-glue-deb/pyproject.toml
+++ b/pulp-glue-deb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pulp-glue-deb"
-version = "0.3.0.dev"
+version = "0.4.0.dev"
 description = "Version agnostic glue library to talk to pulpcore's REST API. (deb plugin)"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pulpcore/cli/deb/__init__.py
+++ b/pulpcore/cli/deb/__init__.py
@@ -9,7 +9,7 @@ from pulpcore.cli.deb.publication import publication
 from pulpcore.cli.deb.remote import remote
 from pulpcore.cli.deb.repository import repository
 
-__version__ = "0.3.0.dev"
+__version__ = "0.4.0.dev"
 
 
 @pulp_group(name="deb")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pulp-cli-deb"
-version = "0.3.0.dev"
+version = "0.4.0.dev"
 description = "Command line interface to talk to pulpcore's REST API. (Deb plugin commands)"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -24,7 +24,7 @@ classifiers=[
 ]
 dependencies = [
   "pulp-cli>=0.23.2,<0.36",
-  "pulp-glue-deb==0.3.0.dev",
+  "pulp-glue-deb==0.4.0.dev",
 ]
 
 [project.urls]
@@ -152,7 +152,7 @@ ignore_missing_imports = true
 
 [tool.bumpversion]
 # This section is managed by the cookiecutter templates.
-current_version = "0.3.0.dev"
+current_version = "0.4.0.dev"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.(?P<release>[a-z]+))?"


### PR DESCRIPTION
"Create Release Branch" failed because apparently we never bumped the version after the last release branching.

See: https://github.com/pulp/pulp-cli-deb/actions/runs/17100063786/job/48493886253