### PR TITLE
Add support for creating package_release_component content

### DIFF
--- a/CHANGES/245.feature
+++ b/CHANGES/245.feature
@@ -1,0 +1,1 @@
+Added support for ``pulp deb content --type package_release_component create``, allowing an existing package to be associated with one or more release components (and thus distributions) within a repository without re-uploading.

--- a/src/pulpcore/cli/deb/content.py
+++ b/src/pulpcore/cli/deb/content.py
@@ -78,7 +78,33 @@ repository_option = resource_option(
         "Repository to add the content to in the form '[[<plugin>:]<resource_type>:]<name>' or by "
         "href."
     ),
-    allowed_with_contexts=(PulpDebPackageContext, PulpDebReleaseComponentContext),
+    allowed_with_contexts=(
+        PulpDebPackageContext,
+        PulpDebPackageReleaseComponentContext,
+        PulpDebReleaseComponentContext,
+    ),
+)
+
+package_option = resource_option(
+    "--package",
+    default_plugin="deb",
+    default_type="package",
+    context_table={"deb:package": PulpDebPackageContext},
+    href_pattern=PulpDebPackageContext.HREF_PATTERN,
+    required=True,
+    help=_("Package to associate with a release component, by href."),
+    allowed_with_contexts=(PulpDebPackageReleaseComponentContext,),
+)
+
+release_component_option = resource_option(
+    "--release-component",
+    default_plugin="deb",
+    default_type="release_component",
+    context_table={"deb:release_component": PulpDebReleaseComponentContext},
+    href_pattern=PulpDebReleaseComponentContext.HREF_PATTERN,
+    required=True,
+    help=_("Release component the package should be associated with, by href."),
+    allowed_with_contexts=(PulpDebPackageReleaseComponentContext,),
 )
 
 
@@ -285,12 +311,18 @@ create_options = [
         help=_("The APT repo component to use"),
         allowed_with_contexts=(PulpDebReleaseComponentContext,),
     ),
+    package_option,
+    release_component_option,
     repository_option,
 ]
 content.add_command(
     create_command(
         decorators=create_options,
-        allowed_with_contexts=(PulpDebPackageContext, PulpDebReleaseComponentContext),
+        allowed_with_contexts=(
+            PulpDebPackageContext,
+            PulpDebPackageReleaseComponentContext,
+            PulpDebReleaseComponentContext,
+        ),
     )
 )
 

--- a/tests/scripts/pulp_deb/test_deb_content.sh
+++ b/tests/scripts/pulp_deb/test_deb_content.sh
@@ -144,3 +144,21 @@ expect_succ pulp orphan cleanup --content-hrefs "[\"${PACKAGE_HREF}\"]" --protec
 expect_succ pulp deb content --type release_component create --distribution foo --component bar
 RELEASE_COMPONENT_HREF=$(echo "${OUTPUT}" | jq -r .pulp_href)
 expect_succ pulp orphan cleanup --content-hrefs "[\"${RELEASE_COMPONENT_HREF}\"]" --protection-time 0 || true
+
+# Test attaching an already-uploaded package to an additional distribution by
+# creating a package_release_component for an existing release component.
+expect_succ pulp deb content upload --file "${DEB_FILENAME}" --repository "${REPO1_NAME}" --distribution "extra-dist" --component "extra-comp"
+EXTRA_PACKAGE_HREF=$(echo "${OUTPUT}" | jq -r .pulp_href)
+
+expect_succ pulp deb content --type release_component create --distribution second-dist --component extra-comp --repository "${REPO1_NAME}"
+SECOND_RC_HREF=$(echo "${OUTPUT}" | jq -r .pulp_href)
+
+expect_succ pulp deb content --type package_release_component create \
+  --package "${EXTRA_PACKAGE_HREF}" \
+  --release-component "${SECOND_RC_HREF}" \
+  --repository "${REPO1_NAME}"
+
+# The same package should now be referenced by PRCs in two distributions.
+VERSION_HREF=$(pulp deb repository version show --repository "${REPO1_NAME}" | jq -r .pulp_href)
+expect_succ pulp deb content --type package_release_component list --repository-version "${VERSION_HREF}" --package "${EXTRA_PACKAGE_HREF}"
+test "$(echo "${OUTPUT}" | jq -r length)" -ge "2"


### PR DESCRIPTION
Exposes `pulp deb content --type package_release_component create`, which links an already-uploaded package to a release component (and thus a distribution) without re-uploading the package. 

Closes #245